### PR TITLE
Add vibeprompt to Project Documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [CodeGuide](https://www.codeguide.dev/) — Tool that builds documentation for AI-built projects.
 * [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats.
 * [Claude Code Mastery](https://github.com/ShipWithAI/claude-code-mastery) — Structured course for mastering Claude Code workflows, including security, automation, and multi-agent patterns.
+* [vibeprompt](https://vibeprompt.tech) — Free 10-step vibe coding workflow with 56 prompts, 17 deep-dive articles, 46 field-tested fixes, and an interactive AGENTS.md + PRD generator. Open source, MIT licensed.
 
 ---
 


### PR DESCRIPTION
Adds [vibeprompt](https://vibeprompt.tech) to the Project Documentation section.

**What it is:** a free, open-source, web-based resource for vibe coders. Bundles:
- 10-step interactive workflow (localStorage-saved checklists) from idea to shipped
- 56 battle-tested prompts grouped by workflow stage
- 17 long-form articles with real receipts from shipped apps
- 46 field-tested fixes for problems indie devs hit (security, conversion, burnout, etc.)
- Interactive AGENTS.md + PRD generator — fill in fields, get ready-to-use markdown

**Why it fits Project Documentation:** vibeprompt's core artifact is the documentation-generation flow (AGENTS.md templates, PRD format, memory-bank structure) plus the workflow that puts those docs to use. Pairs with CodeGuide, LynxPrompt, and the Claude Code Mastery entries already in this section.

MIT licensed, no sign-up. Source: github.com/dotsystemsdevs/vibe-prompt.

Thanks for maintaining the list! 🙏