### PR TITLE
Add Orca

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [Orca](https://onorca.dev) — An open-source desktop IDE/ADE for running parallel AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode) side-by-side, each in its own isolated git worktree.
 
 ---
 


### PR DESCRIPTION
Adds **Orca** to `Desktop & Local Apps`.

Orca is an open-source (MIT) desktop IDE/ADE (macOS/Windows/Linux, plus a mobile companion) for running a fleet of parallel AI coding agents — Claude Code, Codex, Cursor, Gemini, OpenCode and others — each in its own isolated git worktree, with a built-in terminal, source control, and SSH.

- Source: https://github.com/stablyai/orca
- Website: https://onorca.dev

Placed in `Desktop & Local Apps`, matching the existing format. Thanks!