### PR TITLE
Add AI Coding Tools Guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## Project Documentation
 
+* [AI Coding Tools Guide](https://ai-coding-tools-guide.vercel.app/cursor-alternatives/) — Workflow-based comparisons for Cursor alternatives, Claude Code, Windsurf, Cline, GitHub Copilot, Aider, Continue, and MCP-enabled AI coding.
 * [CodeGuide](https://www.codeguide.dev/) — Tool that builds documentation for AI-built projects.
 * [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats.
 * [Claude Code Mastery](https://github.com/ShipWithAI/claude-code-mastery) — Structured course for mastering Claude Code workflows, including security, automation, and multi-agent patterns.


### PR DESCRIPTION
Adds AI Coding Tools Guide to the Project Documentation section.

The guide compares Cursor alternatives by developer workflow and covers Claude Code, Windsurf, Cline, GitHub Copilot, Aider, Continue, and MCP-enabled AI coding workflows.

Link: https://ai-coding-tools-guide.vercel.app/cursor-alternatives/