### PR TITLE
Add DevIntern

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) — Automatically turns big ideas into task queues.
 * [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) — Compatible with popular AI IDEs, breaks down work into subtasks.
 * [agent-hub](https://github.com/Dominic789654/agent-hub) — Local-first multitask board for routing, sequencing, and observing repo-local coding agents across projects.
+* [DevIntern](https://devintern.com/) — Picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, Gemini CLI, and others), on your machines with your own model keys.
 
 ---
 


### PR DESCRIPTION
## Add DevIntern to AI-Driven Task Management

[DevIntern](https://devintern.com/) is a tool that picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others). It runs on your own machines with your own model keys.

A feasibility gate flags vague tickets back to the tracker with questions, and an optional unattended mode schedules ticket pickup and turns PR review comments into commits.

- Source-available (FSL-1.1), free for interactive use
- Repo: https://github.com/getdevintern/devintern
- Docs: https://devintern.com/docs