### PR TITLE
Add LLMGraph

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [MyVibe](https://myvibe.so/) — Instant deployment for AI-generated web apps. Publish via Claude Code skills or direct upload.
 * [Rosebud AI](https://rosebud.ai) — Vibe coding platform for creating 3D games and interactive web apps with AI.
 * [Forge](https://forge-web.rebaselabs.online/) — AI-powered full-stack app creator with BYOK (bring your own API key). Multi-stage pipeline: planning, architecture, code generation, and verification.
+* [LLMGraph](https://llmgraph.ai) — Browser-based visual builder for LLM workflows; build RAG chatbots and AI agents by canvas or chat, with one-click deploy to a REST API and chat widget.
 
 ---
 


### PR DESCRIPTION
Adds [LLMGraph](https://llmgraph.ai) to the Web-Based Builders section — a browser-based visual builder for LLM workflows (RAG chatbots and AI agents by canvas or chat, one-click deploy to a REST API and chat widget). Entry matches the existing list format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)