### PR TITLE
Add Tura to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [Tura](https://github.com/Tura-AI/tura) — Open-source local coding agent with CLI/TUI/GUI, task-scoped context, macro command execution, verification, and public benchmarks.
 
 ---
 


### PR DESCRIPTION
Hi! I maintain Tura, an AGPL-3.0 local coding agent for repository work. It provides CLI, TUI, and GUI entry points, runs repository commands, verifies changes, and keeps context scoped to the current task.

This PR adds one concise entry at the end of the existing CLI Tools section and follows the section's bullet style.

Repository: https://github.com/Tura-AI/tura
Project site: https://turaai.net/

Thanks for considering it.