### PR TITLE
Add Juggler to Desktop & Local Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [Juggler](https://juggler.studio) — Open-source desktop GUI for AI coding agents with inspectable tool calls, branching session threads, and editable context; runs local plus multi-client P2P from remote browsers, with extensions and BYOK.
 
 ---
 


### PR DESCRIPTION
Adds **Juggler** to the **Desktop & Local Apps** section.

Entry:

> * [Juggler](https://juggler.studio) — Open-source desktop GUI for AI coding agents with inspectable tool calls, branching session threads, and editable context; runs local plus multi-client P2P from remote browsers, with extensions and BYOK.

- Placed at the end of the Desktop & Local Apps section, following the existing format (`*` bullet, em dash, single factual sentence, official site link).
- Disclosure: this is my own project.
