### PR TITLE
Add UIZZE to Extensions & Plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Amazon Q](https://aws.amazon.com/q/developer) — AWS’s generative AI solution for developers.
 * [Superdesign](https://www.superdesign.dev/) — AI design agent for fast UI iterations.
 * [toprank](https://github.com/nowork-studio/toprank) — Open-source Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag and schema markup fixes to WordPress/Strapi/Contentful/Ghost. MIT, 107⭐.
+* [UIZZE](https://uizze.com) — Hosted MCP that gives Codex, Claude Code, Cursor, and Copilot real web and iOS UI references, design contracts, implementation validation, and UI finish gates.
 * [dbForge AI Assistant](https://www.devart.com/dbforge/ai-assistant/) - Integrated AI tool that generates, optimizes, explains, and fixes SQL queries. 
 * [Frontman](https://github.com/frontman-ai/frontman) — Open-source AI agent that lives in your browser — click any element, describe changes in plain English, and get real code edits with hot reload. Works with Next.js, Vite, and Astro.
 * [Mysti](https://github.com/DeepMyst/Mysti) - Multi-agent AI coding assistant for VS Code with brainstorm mode. Supports Claude Code, Codex, Gemini, Cline, and GitHub Copilot.


### PR DESCRIPTION
Adds UIZZE to Extensions & Plugins as a one-line, factual entry.

UIZZE is directly relevant to AI-assisted coding: its hosted MCP gives Codex, Claude Code, Cursor, and Copilot real web and iOS UI references, design contracts, implementation validation, and UI finish gates.

Validation:
- searched the README and open pull requests; no UIZZE duplicate exists
- confirmed https://uizze.com returns HTTP 200
- one README line added; `git diff --check` passes
- `awesome-lint` does not flag the added line; it reports 84 pre-existing errors elsewhere in the README

Disclosure: UIZZE is my project.