### PR TITLE
Add whatbroke to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) — Diff your AI agent's behavior between two runs: tool calls, args, cost, latency, and outcome flips, with flake detection and CI exit codes.
 
 ---
 


### PR DESCRIPTION
Adds whatbroke, a CLI that diffs an AI agent's behavior between two runs so you can see what changed after a prompt or model swap: tool calls, args, cost, latency, outcome flips. Functional and maintained, MIT, TypeScript, on npm as whatbroke-cli. One entry, matched to the section's format.