### PR TITLE
Add TeDDy to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,177 +1,177 @@
-# Awesome Vibe Coding [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-
-> A hand-picked collection of tools and references for building software with the help of AI—through prompts, iterations, and exploration.
-
-## Overview
-
-This list focuses on tools and workflows where AI plays a central role in the development process. Instead of traditional coding, this approach emphasizes describing ideas, iterating quickly, and trusting the process—even when you’re not sure where it’s headed.
-
-*You can find a searchable, more detailed list on [AI For Developers](https://aifordevelopers.org)*
-
-
-----
-
- **Reach thousands of developers building with AI by sponsoring this list, our [newsletter](https://aifordevelopers.substack.com/) and [AI For Developers](https://aifordevelopers.org/). Contact us at [aifordevelopers.org/advertise](https://aifordevelopers.org/advertise)**
-
-----
-
-
-
-## Table of Contents
-
-* [What is](#what-is)
-* [Web-Based Builders](#web-based-builders)
-* [Editors and IDEs](#editors-and-ides)
-* [Mobile Tools](#mobile-tools)
-* [Extensions & Plugins](#extensions--plugins)
-* [Desktop & Local Apps](#desktop--local-apps)
-* [CLI Tools](#cli-tools)
-* [AI-Driven Task Management](#ai-driven-task-management)
-* [Monitoring & Cost Tracking](#monitoring--cost-tracking)
-* [Project Documentation](#project-documentation)
-* [Articles & Updates](#articles--updates)
-* [Contributing](#contributing)
-
----
-
-## What is
-
-* [Karpathy on the "vibe coding" mindset](https://x.com/karpathy/status/1886192184808149383) — Not traditional coding. More like shaping software through language and intuition.
-* [AI Coding Guide by Automata](https://github.com/automata/aicodeguide) — A structured starting point for newcomers using AI-first development approaches.
-
----
-
-## Web-Based Builders
-
-* [Bolt.new](https://bolt.new/) — Rapidly prototype and launch web and mobile apps by prompting.
-* [Lovable](https://lovable.dev/) — Full-stack applications from simple ideas.
-* [Vercel’s v0](https://v0.dev/chat) — Helps design and implement UIs from natural language.
-* [Capacity](https://capacity.so/) — Create production-ready web apps in minutes.
-* [CHAI.new](https://chai.new) — Code and deploy AI agents with prompts.
-* [Replit](https://replit.com/) — Type what you want and let the AI construct it.
-* [Create](https://www.create.xyz/) — Converts text prompts into usable tools or websites.
-* [Trickle](https://www.trickle.so/) — AI-based visual builder for websites and apps.
-* [Tempo](https://www.tempo.new/) — Build React projects much faster through AI assistance.
-* [Softgen](https://softgen.ai/) — Describe a concept and generate a working full-stack app.
-* [Lazy AI](https://getlazy.ai/) — Enterprise-focused prompt-based application builder.
-* [HeyBoss](https://www.heyboss.xyz/) — Generate functional websites quickly.
-* [Creatr](https://getcreatr.com/) — Build landing pages and simple apps instantly.
-* [Rork](https://rork.app/) — A tool focused on generating mobile apps.
-* [Firebase Studio](https://studio.firebase.google.com/) — Google's take on agent-driven full-stack development.
-* [Napkins](https://www.napkins.dev/) — Converts mockups or screenshots into working code.
-* [HeroUI Chat](https://heroui.chat/) — Build interfaces without design expertise.
-* [Rocket.new](https://www.rocket.new/) — Low-code experience for shipping apps.
-* [embedible.io](https://embedible.io/) - AI that transforms your electronics ideas into working projects.
-* [FlyPloy](https://flyploy.com/en) — A modern application deployment platform that simplifies global delivery with one-click deploys, Docker, and Kubernetes support. Ideal for launching AI-assisted applications in seconds.
-* [MyVibe](https://myvibe.so/) — Instant deployment for AI-generated web apps. Publish via Claude Code skills or direct upload.
-* [Rosebud AI](https://rosebud.ai) — Vibe coding platform for creating 3D games and interactive web apps with AI.
-* [Forge](https://forge-web.rebaselabs.online/) — AI-powered full-stack app creator with BYOK (bring your own API key). Multi-stage pipeline: planning, architecture, code generation, and verification.
-
----
-
-## Editors and IDEs
-
-* [Windsurf](https://codeium.com/windsurf) — AI-focused development environment by Codeium.
-* [Cursor](https://www.cursor.com/) — One of the most advanced AI-first code editors.
-* [Zed](https://zed.dev/) — Built for real-time team collaboration with AI assistance.
-* [Amazon Kiro](https://kiro.dev) — An AI-powered IDE from prototype to production.
-
----
-
-## Mobile Tools
-
-* [VibeCode](https://www.vibecodeapp.com/) — A mobile-first app creator powered by AI.
-* [IM.codes](https://github.com/im4codes/imcodes) — Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents.
-
----
-
-## Extensions & Plugins
-
-* [Cline](https://cline.bot/) — Connects to your CLI and editor, interprets natural commands.
-* [Roo Code](https://github.com/RooVetGit/Roo-Code) — An enhanced version of Cline.
-* [avante.nvim](https://github.com/yetone/avante.nvim) — Neovim integration modeled after Cursor’s AI features.
-* [Prompt Tower](https://github.com/backnotprop/prompt-tower) — A prompt creation interface supporting complex code blocks.
-* [Augment Code](https://www.augmentcode.com/) — Tailored for navigating and working with large repositories.
-* [Continue](https://github.com/continuedev/continue) — Build your own in-editor AI agents using plugins and rules.
-* [GitHub Copilot](https://github.com/features/copilot) — Integrated assistant offering code suggestions, chats, and context-aware actions.
-* [Amazon Q](https://aws.amazon.com/q/developer) — AWS’s generative AI solution for developers.
-* [Superdesign](https://www.superdesign.dev/) — AI design agent for fast UI iterations.
-* [toprank](https://github.com/nowork-studio/toprank) — Open-source Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag and schema markup fixes to WordPress/Strapi/Contentful/Ghost. MIT, 107⭐.
-* [dbForge AI Assistant](https://www.devart.com/dbforge/ai-assistant/) - Integrated AI tool that generates, optimizes, explains, and fixes SQL queries. 
-* [Frontman](https://github.com/frontman-ai/frontman) — Open-source AI agent that lives in your browser — click any element, describe changes in plain English, and get real code edits with hot reload. Works with Next.js, Vite, and Astro.
-* [Mysti](https://github.com/DeepMyst/Mysti) - Multi-agent AI coding assistant for VS Code with brainstorm mode. Supports Claude Code, Codex, Gemini, Cline, and GitHub Copilot.
-* [AgentLint](https://github.com/0xmariowu/AgentLint) — 33 evidence-backed checks for AI-friendly repos — file structure, instruction quality, build setup, session continuity, security posture. Claude Code plugin.
-
----
-
-## Desktop & Local Apps
-
-* [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
-* [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
-
----
-
-## CLI Tools
-
-* [claude-code](https://github.com/anthropics/claude-code) — Works across codebases, provides explanations, automates tasks.
-* [memov](https://github.com/memovai/memov) — Git-based, traceable memory layer for Claude Code.
-* [aider](https://aider.chat/) — Code side-by-side with AI from your terminal.
-* [Goose](https://block.github.io/goose/) — Local agent framework compatible with multiple models.
-* [MyCoder.ai](https://github.com/drivecore/mycoder) — Modular agent with GitHub integration.
-* [RA.Aid](https://github.com/ai-christianson/RA.Aid) — Task-based AI built with LangGraph.
-* [CodeSelect](https://github.com/maynetee/codeselect) — Sends structured source context to LLMs.
-* [OpenAI Codex CLI](https://github.com/openai/codex) — Experimental terminal assistant.
-* [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Terminal assistant built around Google Gemini.
-* [ReviewCerberus](https://github.com/Kirill89/reviewcerberus) - Open-source AI code review tool for analyzing git branch differences with comprehensive security, performance, and quality analysis.
-* [OpenPaw](https://github.com/daxaur/openpaw) — Turns Claude Code into a personal assistant with 38 skills for email, calendar, Spotify, smart home, and more.
-* [Autohand Code CLI](https://github.com/autohandai/code-cli) — Self-evolving autonomous coding agent for the terminal with 40+ tools, multi-LLM support, and a modular skills system.
-* [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
-* [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
-* [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
-
----
-
-## AI-Driven Task Management
-
-* [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) — Automatically turns big ideas into task queues.
-* [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) — Compatible with popular AI IDEs, breaks down work into subtasks.
-* [agent-hub](https://github.com/Dominic789654/agent-hub) — Local-first multitask board for routing, sequencing, and observing repo-local coding agents across projects.
-
----
-
-## Monitoring & Cost Tracking
-
-* [Budi](https://github.com/siropkin/budi) — Local-first cost analytics for AI coding agents. Tracks token usage and spend across Claude Code and Cursor.
-
----
-
-## Project Documentation
-
-* [CodeGuide](https://www.codeguide.dev/) — Tool that builds documentation for AI-built projects.
-* [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats.
-* [Claude Code Mastery](https://github.com/ShipWithAI/claude-code-mastery) — Structured course for mastering Claude Code workflows, including security, automation, and multi-agent patterns.
-
----
-
-## Articles & Updates
-
-* [Prompt Engineering for Developers](https://addyo.substack.com/p/the-prompt-engineering-playbook-for)
-* [What Vibe Coding Actually Means](https://theconversation.com/what-is-vibe-coding-a-computer-scientist-explains-what-it-means-to-have-ai-write-computer-code-and-what-risks-that-can-entail-257172)
-* [LLM Pair Programming](https://pmbanugo.me/blog/peer-programming-with-llms)
-* [The Way of Code](https://www.thewayofcode.com/)
-* [2025 Tooling Overview on LinkedIn](https://www.linkedin.com/pulse/state-vibe-coding-tools-may-2025-nufar-gaspar-x1znf)
-* [Karpathy on Menus and Vibes](https://karpathy.bearblog.dev/vibe-coding-menugen/)
-* [Fireship: Mindset Video](https://www.youtube.com/watch?v=Tw18-4U7mts)
-* [Ars Technica on AI Development Futures](https://arstechnica.com/ai/2025/03/is-vibe-coding-with-ai-gnarly-or-reckless-maybe-some-of-both/)
-* [The New Stack – Everyone Can Program](https://thenewstack.io/vibe-coding-where-everyone-can-speak-computer-programming/)
-* [NYTimes: Personal Vibe Coding Experience](https://www.nytimes.com/2025/02/27/technology/personaltech/vibecoding-ai-software-programming.html)
-* [CodingButVibes – What Is Vibe Coding](https://www.codingbutvibes.com/what-is-vibe-coding) — Practical breakdown of the vibe coding approach, with tool comparisons and real developer workflows.
-* [Reddit: /r/vibecoding](https://www.reddit.com/r/vibecoding/)
-* [Reddit: /r/ChatGPTCoding](https://www.reddit.com/r/ChatGPTCoding/)
-* [Vibe Engineering](https://www.manning.com/books/vibe-engineering)
-
----
-
-## Contributing
-
-Found something interesting or built your own tool? Contributions are encouraged—see the [contribution guide](CONTRIBUTING.md) for details.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.
+* [TeDDy](https://github.com/atte500/TeDDy) — Markdown-driven coding harness that enforces TDD, Hexagonal Architecture, and vertical slicing. Python, AGPL-3.0.


### PR DESCRIPTION
Add [TeDDy](https://github.com/atte500/TeDDy) — an opinionated coding harness that embeds TDD, Hexagonal Architecture, and vertical slicing into a Markdown-driven workflow.

- **Language:** Python
- **License:** AGPL-3.0
- **Category:** CLI Tools