### PR TITLE
Add stepback to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Autohand Code CLI](https://github.com/autohandai/code-cli) — Self-evolving autonomous coding agent for the terminal with 40+ tools, multi-LLM support, and a modular skills system.
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
+* [stepback](https://github.com/Archerkattri/stepback) — Snapshots your working tree as any AI agent edits, then rewinds or redoes to an exact checkpoint via isolated git shadow-refs, never touching your real HEAD or history.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
 
 ---


### PR DESCRIPTION
## Summary

Adds [stepback](https://github.com/Archerkattri/stepback) to CLI Tools, alphabetically between sober-coding and VibeGrid. This is my own project, disclosed per CONTRIBUTING.md.

stepback wraps any AI coding agent and snapshots the working tree as it edits files, using isolated git shadow-refs (`refs/checkpoints/`) written through a private index, so the real HEAD, index, and branch history are never touched. `stepback rewind` restores an exact prior checkpoint (binary files, symlinks, additions, deletions all handled) with a diff preview and a redo stack. When Claude Code or Codex is detected it also does best-effort conversation-transcript rewind, so a rewind can resume the chat, not just reset the code — directly useful for a bad vibe-coding turn.

## Why it fits

It's the "undo my agent" tool for exactly this list's audience: functional, MIT licensed, `pip install stepback`, no vaporware — 67 tests, CI on 3.11/3.12.

## Links

- Repo: https://github.com/Archerkattri/stepback
- PyPI: https://pypi.org/project/stepback/