### PR TITLE
Add DevProjex

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,8 +106,9 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## Desktop & Local Apps
 
-* [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [DevProjex](https://github.com/Avazbek22/DevProjex) — Builds clean, AI-ready project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export through a fast GUI and CLI.
+* [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 
 ---
 


### PR DESCRIPTION
Adds DevProjex to Desktop & Local Apps as a local-first cross-platform codebase-context app for coding workflows. It now provides GUI, TUI, CLI, and a built-in read-only MCP server for selecting, previewing, redacting, compressing, and packing project context for coding agents.

I maintain DevProjex.