### PR TITLE
Add PinkCode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,8 +106,9 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## Desktop & Local Apps
 
-* [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
+* [PinkCode](https://github.com/3xian/PinkCode) — Open-source desktop GUI for running multiple Grok Build coding-agent sessions in parallel, with live task timelines, usage visualizations, file-change review, and permission controls.
 
 ---
 


### PR DESCRIPTION
Adds [PinkCode](https://github.com/3xian/PinkCode) to **Desktop & Local Apps** and keeps that section alphabetically ordered.

PinkCode is a functional, documented, open-source desktop GUI for Grok Build. It runs multiple coding-agent sessions in parallel and provides live task timelines, usage visualizations, file-change review, and permission controls over ACP.

Disclosure: PinkCode is my own project and I maintain it.