### PR TITLE
Add CUT3 to Editors and IDEs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Cursor](https://www.cursor.com/) — One of the most advanced AI-first code editors.
 * [Zed](https://zed.dev/) — Built for real-time team collaboration with AI assistance.
 * [Amazon Kiro](https://kiro.dev) — An AI-powered IDE from prototype to production.
+* [CUT3](https://cut3.ai) — Applies the vibe coding loop to video editing: prompt an agent to rewrite the timeline, then review the diff before it lands.
 
 ---
 


### PR DESCRIPTION
Adds CUT3 to Editors and IDEs.

CUT3 applies the vibe coding loop to video editing: you describe the change in chat, an agent rewrites the timeline, and the change comes back as a diff you approve or reject before it lands.

Per CONTRIBUTING: one entry, single factual sentence, em dash separator, direct link to the official site with no referral parameters. It is live and free to try.