### PR TITLE
Add Codex How To learning guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,9 +147,10 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## Project Documentation
 
-* [CodeGuide](https://www.codeguide.dev/) — Tool that builds documentation for AI-built projects.
-* [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats.
 * [Claude Code Mastery](https://github.com/ShipWithAI/claude-code-mastery) — Structured course for mastering Claude Code workflows, including security, automation, and multi-agent patterns.
+* [CodeGuide](https://www.codeguide.dev/) — Tool that builds documentation for AI-built projects.
+* [Codex How To](https://github.com/Phelan164/codex-howto) — Engineering-first OpenAI Codex guide with progressive modules, installable skills, runnable tests, and measured workflows for implementation, review, security, and orchestration.
+* [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats.
 
 ---
 


### PR DESCRIPTION
## Summary

- add Codex How To to Project Documentation
- keep the section alphabetically ordered

## Why it fits

Codex How To is an engineering-first OpenAI Codex learning resource with 14 progressive modules, 9 installable skills, a dependency-free playground, and measurement protocols covering implementation, testing, review, security, orchestration, and context efficiency.

Maintainer disclosure: I maintain Codex How To. This PR adds only that project, and I checked the README plus open and closed issues/PRs for duplicates before submitting.

## Validation

- `git diff --check`
- repository link resolves: https://github.com/Phelan164/codex-howto