### PR TITLE
Add Tintpad to Desktop & Local Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [Tintpad](https://tintpad.com/) — Native macOS menu-bar launcher that opens your terminal at a chosen git repo with an AI coding agent (Claude Code, Codex, Gemini CLI) running.
 
 ---
 


### PR DESCRIPTION
Adds [Tintpad](https://github.com/sorkila/tintpad), a free, open-source (MIT) native macOS menu-bar launcher: a global hotkey opens a palette, fuzzy-find a git repo (frecency-ranked), pick an agent (Claude Code, Codex, Gemini CLI) and run mode, and your own terminal opens at that repo with the agent already running. Local-only, no accounts.

One topic per PR, factual one-line description, checked open PRs for duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)