### PR TITLE
Add Boost to Monitoring & Cost Tracking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## Monitoring & Cost Tracking
 
+* [Boost](https://boost.jfrog.com/) — Free CLI that filters terminal and CI output before it reaches Cursor, Claude Code, and Codex, typically reducing log tokens by 60–90%, with reversible retrieval and local performance reports.
 * [Budi](https://github.com/siropkin/budi) — Local-first cost analytics for AI coding agents. Tracks token usage and spend across Claude Code and Cursor.
 
 ---


### PR DESCRIPTION
## Summary

Add [Boost](https://boost.jfrog.com/) to **Monitoring & Cost Tracking**, alphabetically before Budi.

## Why it fits

Boost is a free CLI that filters terminal and CI output before it reaches Cursor, Claude Code, or Codex, typically reducing log tokens by 60–90%. Full output remains recoverable, and local reports show token savings and command performance.

GitHub: https://github.com/jfrog/boost

Disclosure: I work on Boost at JFrog.

## Checks

- One factual entry in the existing format.
- Official link with no referral parameters.
- `git diff --check` passes.