### PR TITLE
Add BitFun to Desktop & Local Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## Desktop & Local Apps
 
+* [BitFun](https://github.com/GCWing/BitFun) — Open-source cross-platform desktop agent for planning, editing, testing, reviewing, and committing code in real Git repositories.
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
 


### PR DESCRIPTION
## What is being added

Adds [BitFun](https://github.com/GCWing/BitFun) to **Desktop & Local Apps**.

BitFun is an open-source cross-platform desktop agent for working in real Git repositories. It supports planning, editing, testing, code review, and commits, with a Rust runtime and a desktop interface for macOS, Windows, and Linux.

## Why it fits

It is a functional local application centered on prompt-driven software development, rather than a general AI resource. The entry is one factual sentence and links directly to the canonical source repository.

## Disclosure

This is my own project submission, made on behalf of BitFun.

## Verification

- Searched the README and public PR/issue history for duplicates
- Kept the entry in alphabetical position relative to the surrounding items
- `git diff --check` passes
