### PR TITLE
Add HorizonX to Web-Based Builders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Firebase Studio](https://studio.firebase.google.com/) — Google's take on agent-driven full-stack development.
 * [Napkins](https://www.napkins.dev/) — Converts mockups or screenshots into working code.
 * [HeroUI Chat](https://heroui.chat/) — Build interfaces without design expertise.
+* [HorizonX](https://horizonx.so/) — A UI and code library with Figma assets, React and Tailwind components, and templates for AI-assisted frontend workflows.
 * [Rocket.new](https://www.rocket.new/) — Low-code experience for shipping apps.
 * [embedible.io](https://embedible.io/) - AI that transforms your electronics ideas into working projects.
 * [FlyPloy](https://flyploy.com/en) — A modern application deployment platform that simplifies global delivery with one-click deploys, Docker, and Kubernetes support. Ideal for launching AI-assisted applications in seconds.


### PR DESCRIPTION
## What changed
- Added HorizonX as one focused entry in Web-Based Builders.

## Why it fits
HorizonX provides Figma assets, React and Tailwind components, and templates used alongside AI-assisted frontend workflows such as Cursor, Lovable, and v0. It complements AI builders rather than claiming to be an AI model or IDE.

## Disclosure
I’m Marcelo Cedeno, founder of HorizonX, and this is my own commercial project. This PR requests organic editorial review only; no sponsorship, reciprocal link, guaranteed placement, or preferred anchor is requested. AI assistance was used to polish the concise entry and PR description.

## Checks
- Direct canonical URL
- One resource and one README line
- Concise factual description
- Existing format and em dash