### PR TITLE
Add agent-qa to CLI tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## CLI Tools
 
+* [agent-qa](https://github.com/vostride/agent-qa) — Open-source self-improving QA agent that lets coding agents author and run natural-language web and mobile tests through its CLI, MCP integration, and bundled skills.
 * [claude-code](https://github.com/anthropics/claude-code) — Works across codebases, provides explanations, automates tasks.
 * [memov](https://github.com/memovai/memov) — Git-based, traceable memory layer for Claude Code.
 * [aider](https://aider.chat/) — Code side-by-side with AI from your terminal.


### PR DESCRIPTION
## Summary

Adds agent-qa to **CLI Tools** using the list's existing one-resource and em-dash format.

agent-qa lets coding agents author and run natural-language web and mobile tests through a CLI, MCP integration, and bundled skills. Its persistent execution memory and self-healing behavior make it useful in iterative, agent-driven development workflows.

## Checks

- The resource is active, public, and not already listed.
- The repository URL was verified.
- The description is factual and `git diff --check` passes.
- Only one resource is added.

Project disclosure: this submission is for agent-qa itself.
