### PR TITLE
Add Engine to Tools

### DIFF
--- a/content/tools/engine.md
+++ b/content/tools/engine.md
@@ -1,0 +1,22 @@
+---
+title: "Engine"
+description: "A repository-native harness for Claude Code and Codex that carries project state, memory, and build controls across sessions and prepares reviewable pull requests."
+category: "Terminal Agent"
+website: "https://github.com/StarshipSuperjam/engine-template"
+pricing: "Free and open source (Apache-2.0); bring your own Claude Code or Codex"
+tags: ["harness", "cli", "open-source", "memory"]
+weight: 900
+rank: 3
+---
+
+Engine sits on top of a terminal coding agent (Claude Code or Codex) and gives a project durable state, memory, decision records, and guardrails, so each session starts grounded instead of from scratch. Work reaches the main branch only through a pull request the operator approves and merges.
+
+## Why it stands out
+
+- **Persistent project memory.** State, decisions, and prior findings carry between sessions rather than being re-derived each time.
+- **Deliberate build controls.** Building is opt-in per session, and changes are delivered as evidence-backed pull requests.
+- **Host-agnostic.** Runs through whichever supported terminal agent you already use.
+
+## Good for
+
+Non-engineers and teams who want to direct and approve real project work without reading code, with continuity and review boundaries kept across sessions.


### PR DESCRIPTION
## Summary

Adds **Engine** to Tools → Terminal Agent. Engine is a repository-native harness for Claude Code and Codex that carries project state, memory, and build controls across sessions and prepares reviewable pull requests.

## Disclosure

This is my own project — sharing it because it's directly relevant to vibe coding: it's the harness layer a terminal coding agent runs within.

## How this follows the repo

- Added as a content file `content/tools/engine.md` (the source of truth), matching the front-matter of existing Terminal Agent entries (e.g. `claude-code.md`, `codex-cli.md`).
- Verified it renders by running `python3 scripts/generate_readme.py` — Engine appears under Tools → Terminal Agent.
- Left `readme.md` regeneration to your pipeline; I didn't hand-edit it, since the committed `readme.md` has diverged from the current generator output. (Heads up: `CONTRIBUTING.md` still says to edit `readme.md` directly, which looks stale relative to the `content/` + generator pipeline — happy to open a separate PR to update the guide if useful.)
- `weight`/`rank` are modest placeholder values (`rank: 3`); adjust to your curation.

Factual description, no emoji or superlatives, per the contributing guidelines.
