### PR TITLE
Add Sillage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [VibeCode](https://www.vibecodeapp.com/) — A mobile-first app creator powered by AI.
 * [IM.codes](https://github.com/im4codes/imcodes) — Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents.
+* [Sillage](https://github.com/MarlBurroW/sillage) - Self-hosted, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine, with sessions that outlive the client, full-text search, an IDE panel, and an installable PWA.
 
 ---
 


### PR DESCRIPTION
Adds Sillage to the Mobile Tools section (kept alphabetically ordered between IM.codes and VibeCode).

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (the official agent harnesses, without a terminal). Sessions outlive the client, full-text search over every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.

Repo: https://github.com/MarlBurroW/sillage

Disclosure: I am the author of Sillage. The entry is a single, factual line matching the existing format (I used a hyphen separator to keep the description plain). Happy to adjust wording or placement if needed.