### PR TITLE
Add Portable Handoff to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [Portable Handoff](https://github.com/legoambarish/portable-handoff) — Compacts a coding session into a local Markdown/JSON file for resuming in a different chat or a different tool, with verified Git facts instead of a model's recollection.
 
 ---
 


### PR DESCRIPTION
This is my own project, disclosed per the contributing guide.

Portable Handoff is a local-first CLI that compacts a coding session into a Markdown/JSON capsule for resuming in a different chat or a different tool. Deterministic Git facts (branch, commit, whether it was ever pushed) come from a small stdlib-only script, not the model's recollection; every claim is labeled with where it came from. Placed next to VibeGrid at the end of CLI Tools.