### PR TITLE
Add Vibe-Coding Prompt Template to Skills

### DIFF
--- a/content/skills/vibe-coding-prompt-template.md
+++ b/content/skills/vibe-coding-prompt-template.md
@@ -1,0 +1,21 @@
+---
+title: "Vibe-Coding Prompt Template"
+description: "Five-step planning workflow that turns an idea into a PRD, a technical design, and the AGENTS.md instruction files an AI coding agent builds from."
+category: "Development"
+platform: "Cross-platform"
+website: "https://github.com/KhazP/vibe-coding-prompt-template"
+tags: ["planning", "spec-driven", "agents-md"]
+weight: 700
+---
+
+Vibe-Coding Prompt Template covers the part of the workflow that happens before any code is written. Three staged prompts run in any chat tool take an idea through deep research, a PRD, and a technical design, each one making the model ask clarifying questions before it produces a document. A fourth step compiles those answers into `AGENTS.md` and `agent_docs/`.
+
+The `npx vibeworkflow` CLI installs the planning skills into the agent and drives steps 1-4 as an interview, so the same workflow runs without copy-pasting prompts.
+
+## Why a skill for this
+
+Agents produce more consistent results when the scope, stack, and constraints are settled in a document they can re-read, rather than re-derived from chat history each session. Packaging the planning stages as skills makes that the starting point instead of an optional habit.
+
+## Good for
+
+New projects where the shape of the MVP is still open, and teams who want the same planning artifacts regardless of which agent does the building.


### PR DESCRIPTION
Adds one entry to the **Skills** section: `content/skills/vibe-coding-prompt-template.md`.

**Disclosure:** this is my own project.

**On the file I edited:** `content/` looks like the current source of truth — `scripts/generate_readme.py` builds the list from it, and `content/` landed in "init new list" (Aug 13) while `readme.md` was last touched in April. So this PR adds only the content entry and leaves `readme.md` alone. I ran `python3 scripts/generate_readme.py` locally to check the rendering, then reverted the generated file so the diff stays at one new file — regenerating it here would have replaced the whole legacy `readme.md`, which isn't mine to decide. Rendered line:

```
- [Vibe-Coding Prompt Template](https://github.com/KhazP/vibe-coding-prompt-template) — Five-step planning workflow that turns an idea into a PRD, a technical design, and the AGENTS.md instruction files an AI coding agent builds from. ([review](https://vibecoding.rest/skills/vibe-coding-prompt-template/))
```

Happy to move it to `content/tools/` or edit `readme.md` directly instead — say the word and I'll redo it.

**What it is:** the planning half of vibe coding. Three staged prompts (deep research → PRD → technical design) run in any chat tool, each forcing clarifying questions before it writes a document, then a fourth step compiles the answers into `AGENTS.md` and `agent_docs/`. `npx vibeworkflow` installs the planning skills into the agent and runs steps 1–4 as an interview.

Front matter follows the existing schema (`category: "Development"`, `platform: "Cross-platform"`, weight above the current maximum so it appends). Closest neighbour on the list is Get Shit Done — same spec-first idea, but this one covers the product-definition stages ahead of the spec and is not Claude Code specific.

Free, MIT licensed, 2.8k stars, 360+ forks, actively maintained, on npm as `vibeworkflow`.
