### PR TITLE
Add viberank to Monitoring & Cost Tracking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 ## Monitoring & Cost Tracking
 
 * [Budi](https://github.com/siropkin/budi) — Local-first cost analytics for AI coding agents. Tracks token usage and spend across Claude Code and Cursor.
+* [viberank](https://viberank.app) — Public leaderboard and open dataset for AI coding spend. Reads local ccusage data across Claude Code, Codex, Gemini CLI, Copilot and OpenCode, ranks developers by measured token cost, and publishes the aggregate spend distribution via a free JSON API.
 
 ---
 


### PR DESCRIPTION
Adds one entry to **Monitoring & Cost Tracking**, which currently has a single tool.

```
* [viberank](https://viberank.app) — Public leaderboard and open dataset for AI coding spend. Reads local ccusage data across Claude Code, Codex, Gemini CLI, Copilot and OpenCode, ranks developers by measured token cost, and publishes the aggregate spend distribution via a free JSON API.
```

It complements Budi rather than overlapping: Budi is local-first cost analytics, viberank aggregates the same underlying ccusage data into a public comparison and publishes the distribution as open data. Someone who wants to know whether their spend is normal currently has nothing in this section to answer that.

1,126 developers, ~$10.9M in API-equivalent spend tracked across 17 agents. MIT licensed, `viberank-cli` on npm, and listed on ccusage's own community projects page.

**Disclosure: I maintain viberank.** Happy for the wording to be trimmed or the entry dropped.
