### PR TITLE
Add Instructree to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [Instructree](https://github.com/kotobuki09/instructree) — CLI that maps and lints repository-scoped instructions for Codex, Claude Code, GitHub Copilot, and other coding agents.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Instructree to the CLI Tools section.
- Describe its repository-scoped instruction mapping and linting support for Codex, Claude Code, GitHub Copilot, and other coding agents.

## Project relationship

I maintain Instructree. This submission is for my own project, as permitted by the contribution guide.

## Fit and verification

- The project is public, functional, documented, MIT-licensed, and actively maintained.
- It directly supports AI-assisted coding workflows by auditing the instruction files coding agents may load.
- No existing README entry or open pull request for Instructree was found.
- `git diff --check` passes.
- `npx --yes awesome-lint readme.md` was run; the current README reports repository-wide baseline issues, including rejection of the em-dash separator prescribed by `CONTRIBUTING.md`. This focused change follows the repository's documented em-dash format and does not alter unrelated entries.
