### PR TITLE
Add d1v to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [MyCoder.ai](https://github.com/drivecore/mycoder) — Modular agent with GitHub integration.
 * [RA.Aid](https://github.com/ai-christianson/RA.Aid) — Task-based AI built with LangGraph.
 * [CodeSelect](https://github.com/maynetee/codeselect) — Sends structured source context to LLMs.
+* [d1v](https://github.com/d1vai/d1v-cli) — CLI deployment workflow for AI-built web projects with verified previews and confirmed production releases.
 * [OpenAI Codex CLI](https://github.com/openai/codex) — Experimental terminal assistant.
 * [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Terminal assistant built around Google Gemini.
 * [ReviewCerberus](https://github.com/Kirill89/reviewcerberus) - Open-source AI code review tool for analyzing git branch differences with comprehensive security, performance, and quality analysis.


### PR DESCRIPTION
## Summary

- add d1v to the `CLI Tools` section in `readme.md`
- link to the official `d1vai/d1v-cli` repository

## Why it fits

d1v provides a CLI workflow for deploying AI-built web projects: it creates verified preview deployments and requires explicit confirmation before production releases.

## Disclosure

This is a project maintained by the contributor. The linked repository is public and MIT-licensed.

## Validation

- confirmed the official repository URL is publicly accessible
- confirmed no existing d1v entry or open d1v PR
- checked the Markdown diff with `git diff --check`

No project dependencies, builds, or tests were run for this documentation-only change.