### PR TITLE
Add Yupi's Vibe Coding Guide to Project Documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [CodeGuide](https://www.codeguide.dev/) — Tool that builds documentation for AI-built projects.
 * [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats.
 * [Claude Code Mastery](https://github.com/ShipWithAI/claude-code-mastery) — Structured course for mastering Claude Code workflows, including security, automation, and multi-agent patterns.
+* [Yupi's Vibe Coding Guide](https://github.com/liyupi/ai-guide) — Chinese-language handbook covering tool selection, prompting and context management, end-to-end project builds, and deployment.
 
 ---
 


### PR DESCRIPTION
## What this adds

One entry in **Project Documentation**:

`* [Yupi's Vibe Coding Guide](https://github.com/liyupi/ai-guide) — Chinese-language handbook covering tool selection, prompting and context management, end-to-end project builds, and deployment.`

## Disclosure

This is my own project, as required by the contributing guidelines.

## About the resource

A free, open-source, book-length handbook on vibe coding written by a former Tencent full-stack engineer. It covers tool selection across AI IDEs, CLI agents, IDE plugins and agent platforms; prompting, context management and hallucination handling; dozens of end-to-end project walkthroughs; and deployment, SEO and analytics. It is actively maintained, has no paywall, and ships English and Traditional Chinese translations alongside the Simplified Chinese original.

It sits next to Claude Code Mastery in the same section — a structured learning resource rather than a tool — and is currently the only Chinese-language entry in this list.

## Checklist

- [x] Searched the readme and open PRs — not already listed
- [x] One resource, one PR
- [x] Placed alphabetically at the end of the section
- [x] Format `* [Name](link) — Factual one-sentence description.` with em dash, no marketing language or emoji
- [x] Links to the official repo, no referral link

Made with [Cursor](https://cursor.com)