### PR TITLE
Add Vicoa to Mobile Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [VibeCode](https://www.vibecodeapp.com/) — A mobile-first app creator powered by AI.
 * [IM.codes](https://github.com/im4codes/imcodes) — Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents.
+* [Vicoa](https://vicoa.ai) — Agentic IDE and AI orchestrator for running a team of coding agents (Claude Code, Codex, OpenCode, and more) from desktop, web, or mobile, with real-time sync and push notifications.
 
 ---
 


### PR DESCRIPTION
## What

Adds [Vicoa](https://vicoa.ai) to the Mobile Tools section, next to its closest peer IM.codes (both are mobile/web control layers for terminal coding agents).

## About the project

Vicoa is an open-source, self-hostable agentic IDE and AI orchestrator for running a team of coding agents (Claude Code, Codex, OpenCode, and more) from desktop, web, or mobile, with real-time sync and push notifications.

## Disclosure

This is my own project (maintainer submission), per the "Adding your own project" section of CONTRIBUTING.md. It's young (~30 stars) but functional, documented, and actively developed. Single entry, single PR, not part of a multi-list campaign.