### PR TITLE
Add ClawMetry to Monitoring & Cost Tracking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 ## Monitoring & Cost Tracking
 
 * [Budi](https://github.com/siropkin/budi) — Local-first cost analytics for AI coding agents. Tracks token usage and spend across Claude Code and Cursor.
+* [ClawMetry](https://github.com/vivekchand/clawmetry) — Self-hosted observability and kill switch for coding agents. Reads the session logs runtimes already write on disk, so there is no SDK and nothing in the request path.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 ## Monitoring & Cost Tracking
 
 * [Budi](https://github.com/siropkin/budi) — Local-first cost analytics for AI coding agents. Tracks token usage and spend across Claude Code and Cursor.
-* [ClawMetry](https://github.com/vivekchand/clawmetry) — Self-hosted observability and kill switch for coding agents. Reads the session logs runtimes already write on disk, so there is no SDK and nothing in the request path.
+* [ClawMetry](https://github.com/vivekchand/clawmetry) — Self-hosted observability and kill switch for coding agents. Reads the session logs runtimes already write on disk, so there is no SDK and nothing in the request path. [Website](https://clawmetry.com)
 
 ---
 


### PR DESCRIPTION
Disclosure: this is my own project. ClawMetry (MIT, open-core) is a self-hosted, local-first observability dashboard and kill switch for coding agents: `pip install clawmetry && clawmetry`, zero config. It fits Monitoring & Cost Tracking because it shows sessions, transcripts, tool calls, tokens and cache-aware cost per session and per model across runtimes such as Claude Code, Codex, Cursor, Gemini CLI, Aider, Goose, Cline and Copilot, alongside Budi's cost analytics. A Guard tab can pause, stop or kill a runaway agent; that is opt-in and off by default.

How it gets its data: it reads the session logs the runtimes already write on disk, so there is no SDK to install, nothing sits in the request path, and nothing leaves the machine by default (cloud sync is optional and end-to-end encrypted). Pricing, to be plain about it: OpenClaw and NemoClaw are free in the open-source app; the other runtimes need ClawMetry Cloud or a self-hosted Pro license. The entry is placed alphabetically after Budi and follows the section's existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr

Website: https://clawmetry.com
