### PR TITLE
Add YYLO to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [YYLO](https://github.com/yylo-dev/yylo) — Command-line orchestrator for coding agents: each task runs in a dedicated branch/worktree with typed task, validation, merge, and release-readiness boundaries, and the merge queue owns risk-based review.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [YYLO](https://github.com/yylo-dev/yylo) to the **CLI Tools** section (appended at the section tail — "YYLO" also sorts last alphabetically, so placement follows the contributing guidelines).

YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. Each task runs in a dedicated branch/worktree with typed task, validation, merge, and release-readiness boundaries, and a merge queue owns risk-based review. It sits alongside the section's existing coding-agent CLIs (Bernstein, VibeGrid, claude-code, aider, Goose).

## Quality signals

- MIT-licensed, installable via `npm install -g @yylo/cli` ([@yylo/cli on npm](https://www.npmjs.com/package/@yylo/cli))
- Actively maintained: near-daily pushes since January 2026 (57 stars)
- Documented: quickstart, English docs, usage examples in the README

## Checks

- Searched `readme.md` and the open PRs — YYLO is not already listed or pending in another PR
- Matches the entry format (`* [Name](link) — one factual sentence.`, em dash, no marketing language)
- Single-line diff, one resource per PR, no other files touched

## Disclosure

I'm on the team that builds YYLO (self-submission, disclosed per the contributing guidelines). This PR was prepared with an AI coding agent and reviewed by me line-by-line — happy to adjust the description for tone or length before merge.
