### PR TITLE
Add ContextStream MCP listing

### DIFF
--- a/content/mcp-servers/contextstream.md
+++ b/content/mcp-servers/contextstream.md
@@ -1,0 +1,20 @@
+---
+title: "ContextStream"
+description: "Shared project context for Cursor, Claude Code, Codex, Grok, and other MCP coding agents."
+category: "Dev Tools"
+publisher: "ContextStream"
+website: "https://contextstream.io"
+install: "https://mcp.contextstream.io/mcp"
+tags: ["context", "coding", "mcp"]
+weight: 165
+---
+
+ContextStream is a remote MCP server at https://mcp.contextstream.io/mcp that gives coding agents shared project context: indexed code, decisions, plans, and team sources, scoped to the current project.
+
+## Why it matters
+
+Coding agents start each session without the project's prior decisions and constraints. ContextStream supplies that context over MCP so the next session continues from the same project state.
+
+## Good for
+
+Teams using Cursor, Claude Code, Codex, or Grok who want the same project context in every agent session. Benchmarks: https://contextstream.io/benchmarks.

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 ## Extensions & Plugins
 
 * [Cline](https://cline.bot/) — Connects to your CLI and editor, interprets natural commands.
+* [ContextStream](https://contextstream.io) — Shared project context for Cursor, Claude Code, Codex, Grok, and other MCP coding agents.
 * [Roo Code](https://github.com/RooVetGit/Roo-Code) — An enhanced version of Cline.
 * [avante.nvim](https://github.com/yetone/avante.nvim) — Neovim integration modeled after Cursor’s AI features.
 * [Prompt Tower](https://github.com/backnotprop/prompt-tower) — A prompt creation interface supporting complex code blocks.


### PR DESCRIPTION
## Summary

Adds ContextStream as an MCP server used while coding with AI agents.

- `readme.md`: Extensions & Plugins, next to other coding-agent connectors
- `content/mcp-servers/contextstream.md`: directory page for the remote MCP endpoint

ContextStream is shared project context for Cursor, Claude Code, Codex, Grok, and the rest. Intelligence isn’t the bottleneck. Context is.

- Site: https://contextstream.io
- Remote MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks

Disclosure: I work on ContextStream. This is the only ContextStream entry I am submitting to this list.