### PR TITLE
Add VibeFuse to Desktop & Local Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [VibeFuse](https://fuseintelligence.org/products/vibefuse) — Free Windows desktop harness that runs Claude Code, Codex CLI, Gemini CLI, Cursor, and Qwen as draggable widgets on one shared canvas, with an open marketplace for selling AI skills and widgets (creators keep 80%).
 
 ---
 


### PR DESCRIPTION
## What
Adds one entry to the **Desktop & Local Apps** section:

`* [VibeFuse](https://fuseintelligence.org/products/vibefuse) — Free Windows desktop harness that runs Claude Code, Codex CLI, Gemini CLI, Cursor, and Qwen as draggable widgets on one shared canvas, with an open marketplace for selling AI skills and widgets (creators keep 80%).`

## Why
VibeFuse is directly relevant to vibe coding: it is a desktop harness whose whole purpose is orchestrating the coding agents this list already covers (Claude Code, Codex CLI, Gemini CLI, Cursor, Qwen) side by side on one canvas, with terminals and browsers alongside.

- Functional and maintained: current release v0.1.16, free download, live docs at https://fuseintelligence.org/docs/vibefuse
- Checked the README and open PRs/issues first — no existing VibeFuse entry (search-first rule honored)
- One resource per line, one topic per PR; placed alphabetically at the end of the section (after ClaudeCode Launchpad CLI, Dyad); em dash, single sentence, no marketing superlatives or emoji
- Links to the tool's official product page, not an affiliate link

## Disclosure
I am the founder of VibeFuse (Fuse Intelligence). Submitting my own project per CONTRIBUTING.md's "Adding your own project" section — this is my strongest and only entry, no other projects from my org in this PR.