### PR TITLE
Add OrcaReplay to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — Records a coding-agent session and replays it back to the agent with no model called; forks a checkpoint onto other models to compare.
 
 ---
 


### PR DESCRIPTION
Adds OrcaReplay to **CLI Tools**, one resource, one line.

**Disclosure: I work on it.** Apache-2.0, no paid tier.

## What it is, and why it is not a competitor to the rest of this section

Every other entry here — `claude-code`, `aider`, `Goose`, `Codex CLI`, `Gemini CLI`, `RA.Aid` — *is* an agent. This one is not. It records one and plays the recording back:

```console
$ orca record claude -- -p "fix the failing test"
$ orca replay last
info replaying exchanges=8 egress=blocked
info replay.done reused=8/8 exact=8 divergences=0 exit=0
```

The agent runs again against the recorded bytes, no provider called and no tokens spent. It is useless on its own — it needs one of the agents above to point at — so it reads as a companion to this section rather than another entry competing in it.

The vibe-coding angle: when a run goes sideways you normally re-run and hope, paying again and getting a different answer. Replaying pins the model's half, so you can change your prompt, your rules file or your tooling and see what *your* change did. From a checkpoint it can also continue live on a different model — `orca compare last --models a,b,c --verify "npm test"` makes the verify command's exit code the verdict instead of eyeballing three diffs.

`memov` is the nearest neighbour in spirit: it keeps a traceable memory layer for Claude Code; this keeps the wire traffic.

## Two notes on your guidelines

- **Format.** CONTRIBUTING specifies `- [Tool](url) — description`, but every entry in CLI Tools currently uses `*`. I matched the section so the file stays internally consistent; say the word and I will switch to `-`.
- **Alphabetical order.** The guideline asks for it, and CLI Tools is not currently ordered (`claude-code, memov, aider, Goose, …`). Rather than insert into a sort that does not exist, I appended. Happy to send a separate PR sorting the section if that is wanted — it seemed like something you would rather decide than have arrive unannounced.

## Scope

"No model called" means **no model provider is called**. Replay still executes recorded tool calls for real, so a recorded `curl` reaches the network. It is not a sandbox.
